### PR TITLE
In-place modification of render targets in post-processing steps

### DIFF
--- a/Example/WorkingDir/Shaders/Bloom/BloomComposite.gsh
+++ b/Example/WorkingDir/Shaders/Bloom/BloomComposite.gsh
@@ -1,13 +1,12 @@
 #include "../ShaderDefines.h"
 
 RW_Texture2D_Arr<float4> Bloom : register(u0);
-RW_Texture2D_Arr<float4> InputTexture : register(u1);
-RW_Texture2D_Arr<float4> OutputTexture : register(u2);
+RW_Texture2D_Arr<float4> OutputTexture : register(u1);
 
 #if defined (COMPUTE)
 [N_THREADS(8, 8, 1)]
 void main(uint3 DTid : S_INPUT_DISPATCH_ID)
 {
-	OutputTexture[DTid] = InputTexture[DTid] + Bloom[DTid];
+	OutputTexture[DTid] = OutputTexture[DTid] + Bloom[DTid];
 }
 #endif

--- a/Example/WorkingDir/Shaders/TonemapAndGammaCorrect.gsh
+++ b/Example/WorkingDir/Shaders/TonemapAndGammaCorrect.gsh
@@ -1,7 +1,6 @@
 #include "ShaderDefines.h"
 
-RW_Texture2D_Arr<float4> Input : register(u0);
-RW_Texture2D_Arr<float4> Output : register(u1);
+RW_Texture2D_Arr<float4> Output : register(u0);
 
 ConstantBuffer<SceneData> sd : register(b0);
 
@@ -36,7 +35,7 @@ float3 Uncharted2ToneMapping(float3 color)
 [N_THREADS(8, 8, 1)]
 void main(uint3 DTid : S_INPUT_DISPATCH_ID)
 {
-	float3 color = Input[DTid].rgb;
+	float3 color = Output[DTid].rgb;
 
     color = Uncharted2ToneMapping(color);
 	float Gamma = 1. / 2.2;

--- a/Example/main.cpp
+++ b/Example/main.cpp
@@ -62,7 +62,7 @@ int main()
 	Gecko::RenderPassHandle bloomPass = renderer->CreateRenderPass<Gecko::BloomPass>("Bloom", BloomConfigData);
 
 	Gecko::ToneMappingGammaCorrectionPass::ConfigData ToneMappingGammaCorrectionConfigData;
-	ToneMappingGammaCorrectionConfigData.PrevPass = bloomPass;
+	ToneMappingGammaCorrectionConfigData.PrevPassOutput = renderer->GetRenderPassByHandle(bloomPass)->GetOutputHandle();
 	Gecko::RenderPassHandle toneMappingGammaCorrectionPass = 
 		renderer->CreateRenderPass<Gecko::ToneMappingGammaCorrectionPass>("ToneMappingGammaCorrection",
 			ToneMappingGammaCorrectionConfigData);

--- a/Example/main.cpp
+++ b/Example/main.cpp
@@ -58,7 +58,7 @@ int main()
 	Gecko::FXAAPass::ConfigData FXAAConfigData(deferredPBRPass);
 	Gecko::RenderPassHandle FXAAPass = renderer->CreateRenderPass<Gecko::FXAAPass>("FXAA", FXAAConfigData);
 
-	Gecko::BloomPass::ConfigData BloomConfigData(FXAAPass);
+	Gecko::BloomPass::ConfigData BloomConfigData(renderer->GetRenderPassByHandle(FXAAPass)->GetOutputHandle());
 	Gecko::RenderPassHandle bloomPass = renderer->CreateRenderPass<Gecko::BloomPass>("Bloom", BloomConfigData);
 
 	Gecko::ToneMappingGammaCorrectionPass::ConfigData ToneMappingGammaCorrectionConfigData;

--- a/Include/Rendering/Frontend/Renderer/RenderPasses/BloomPass.h
+++ b/Include/Rendering/Frontend/Renderer/RenderPasses/BloomPass.h
@@ -20,13 +20,13 @@ public:
 	struct ConfigData : public BaseConfigData
 	{
 		ConfigData() :
-			PrevPass(RenderPassHandle())
+			PrevPassOutput(RenderTargetHandle())
 		{}
-		ConfigData(RenderPassHandle handle) :
-			PrevPass(handle)
+		ConfigData(RenderTargetHandle handle) :
+			PrevPassOutput(handle)
 		{}
 		
-		RenderPassHandle PrevPass;
+		RenderTargetHandle PrevPassOutput;
 	};
 
 	BloomPass() = default;
@@ -51,9 +51,6 @@ private:
 	ComputePipelineHandle m_UpScalePipelineHandle;
 	ComputePipelineHandle m_ThresholdPipelineHandle;
 	ComputePipelineHandle m_CompositePipelineHandle;
-
-	ConfigData m_ConfigData;
-
 };
 
 }

--- a/Include/Rendering/Frontend/Renderer/RenderPasses/ToneMappingGammaCorrectionPass.h
+++ b/Include/Rendering/Frontend/Renderer/RenderPasses/ToneMappingGammaCorrectionPass.h
@@ -13,13 +13,13 @@ public:
 	struct ConfigData : public BaseConfigData
 	{
 		ConfigData() :
-			PrevPass(RenderPassHandle())
+			PrevPassOutput(RenderTargetHandle())
 		{}
-		ConfigData(RenderPassHandle handle) :
-			PrevPass(handle)
+		ConfigData(RenderTargetHandle handle) :
+			PrevPassOutput(handle)
 		{}
-
-		RenderPassHandle PrevPass;
+		
+		RenderTargetHandle PrevPassOutput;
 	};
 
 	ToneMappingGammaCorrectionPass() = default;
@@ -36,8 +36,6 @@ protected:
 
 private:
 	ComputePipelineHandle TonemapAndGammaCorrectPipelineHandle;
-
-	ConfigData m_ConfigData;
 };
 
 }

--- a/src/Rendering/Frontend/Renderer/RenderPasses/ToneMappingGammaCorrectionPass.cpp
+++ b/src/Rendering/Frontend/Renderer/RenderPasses/ToneMappingGammaCorrectionPass.cpp
@@ -20,8 +20,7 @@ const void ToneMappingGammaCorrectionPass::SubInit(const Platform::AppInfo& appI
 		computePipelineDesc.ShaderVersion = "5_1";
 		computePipelineDesc.PipelineReadWriteResources = 
 		{
-			PipelineResource::Texture(ShaderType::Compute, 0),
-			PipelineResource::Texture(ShaderType::Compute, 1)
+			PipelineResource::Texture(ShaderType::Compute, 0)
 		};
 		computePipelineDesc.PipelineReadOnlyResources = 
 		{
@@ -31,35 +30,20 @@ const void ToneMappingGammaCorrectionPass::SubInit(const Platform::AppInfo& appI
 		TonemapAndGammaCorrectPipelineHandle = resourceManager->CreateComputePipeline(computePipelineDesc);
 	}
 
-	Gecko::RenderTargetDesc renderTargetDesc;
-	renderTargetDesc.Width = appInfo.Width;
-	renderTargetDesc.Height = appInfo.Height;
-	renderTargetDesc.NumRenderTargets = 1;
-	for (u32 i = 0; i < renderTargetDesc.NumRenderTargets; i++)
-	{
-		renderTargetDesc.RenderTargetClearValues[i].Values[0] = 0.f;
-		renderTargetDesc.RenderTargetClearValues[i].Values[1] = 0.f;
-		renderTargetDesc.RenderTargetClearValues[i].Values[2] = 0.f;
-		renderTargetDesc.RenderTargetClearValues[i].Values[3] = 0.f;
-	}
-	renderTargetDesc.RenderTargetFormats[0] = DataFormat::R32G32B32A32_FLOAT; // output
-
-	m_OutputHandle = resourceManager->CreateRenderTarget(renderTargetDesc, "ToneMappingGammaCorrection", true);
-
-	m_ConfigData = dependencies;
+	// This pass modifies the render target output of the previous pass in-place,
+	// so no need to create a new output target
+	m_OutputHandle = dependencies.PrevPassOutput;
 }
 
 const void ToneMappingGammaCorrectionPass::Render(const SceneRenderInfo& sceneRenderInfo, ResourceManager* resourceManager,
 	const Renderer* renderer, Ref<CommandList> commandList)
 {
-	RenderTarget inputTarget = resourceManager->GetRenderTarget(renderer->GetRenderPassByHandle(m_ConfigData.PrevPass)->GetOutputHandle());
 	RenderTarget outputTarget = resourceManager->GetRenderTarget(m_OutputHandle);
 
 	ComputePipeline TonemapAndGammaCorrectPipeline = resourceManager->GetComputePipeline(TonemapAndGammaCorrectPipelineHandle);
 
 	commandList->BindComputePipeline(TonemapAndGammaCorrectPipeline);
-	commandList->BindAsRWTexture(0, inputTarget.RenderTextures[0]);
-	commandList->BindAsRWTexture(1, outputTarget.RenderTextures[0]);
+	commandList->BindAsRWTexture(0, outputTarget.RenderTextures[0]);
 	u32 currentBackBufferIndex = resourceManager->GetCurrentBackBufferIndex();
 	commandList->BindConstantBuffer(0, resourceManager->SceneDataBuffer[currentBackBufferIndex]);
 	commandList->Dispatch(


### PR DESCRIPTION
- Tonemapping and Bloom pass no longer require a separate output render target; they now modify in-place the output from the previous pass