### PR TITLE
docs: add branching model, PR targeting guidance, and release process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,3 +1,5 @@
+<!-- ⚠️  This PR should target the 'dev' branch. Change the base branch if needed. -->
+
 ## Description
 <!-- What does this PR do? -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,16 +1,24 @@
+<!-- This template is for release PRs: dev → main only.
+     Create via: https://github.com/briandl2000/Gecko/compare/main...dev -->
+
 ## Release to Main
 
-**Version:** `x.y.z` → `x.y.z`
+**Version:** `x.y.z-pre` → `x.y.z-pre`
 
 ### Summary
 <!-- Brief description of what this release includes -->
 
 
 ### Pre-merge Checklist
+- [ ] **Base: `main` ← Head: `dev`** (confirm branches are correct)
 - [ ] Version bumped in `CMakeLists.txt` (`project(Gecko VERSION x.y.z)` and/or `GECKO_VERSION_PRERELEASE`)
 - [ ] `CHANGELOG.md` updated (moved entries from `[Unreleased]` to `[x.y.z]` section)
 - [ ] All CI checks pass (build, test, version check, changelog check)
 - [ ] No known regressions from dev testing
+
+### Merge Instructions
+- Use **Create a merge commit** (not squash or rebase) to preserve dev history
+- After merge, CI will automatically tag and create a GitHub release
 
 ### Release Notes Preview
 <!-- Copy the CHANGELOG.md section for this version here for review -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,26 @@
+<!-- ⚠️  IMPORTANT: Most PRs should target the 'dev' branch, NOT main.
+     If your base branch says 'main', change it to 'dev' unless this is a release PR.
+     Only dev → main merges (releases) should target main. -->
+
 ## Description
 <!-- What does this PR do? -->
 
 
-### Pre-merge Checklist
-- [ ] CI passes (build + tests)
-- [ ] Code follows [coding standards](docs/CODING_STANDARDS.md)
+### Type of Change
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Refactor / cleanup
+- [ ] CI / build system
+- [ ] Documentation
 
-<!-- For PRs to main, use the 'release' template instead:
+### Pre-merge Checklist
+- [ ] **Base branch is `dev`** (not `main`)
+- [ ] CI passes (build + tests on both platforms)
+- [ ] Code follows [coding standards](docs/CODING_STANDARDS.md)
+- [ ] Added/updated tests (if applicable)
+
+### Notes
+<!-- Anything reviewers should know? -->
+
+<!-- For release PRs (dev → main), use the release template instead:
      https://github.com/briandl2000/Gecko/compare/main...dev?template=release.md -->

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,26 +2,54 @@
 
 This is a hobby project with real structure. The goal is to keep changes easy to understand and hard to break.
 
+## Branching Model
+
+```
+feature/xyz ──PR──> dev ──release PR──> main
+                     │                    │
+              (prerelease builds)   (stable releases)
+```
+
+- **`main`** — Stable releases only. Always builds, always tagged. Never commit directly.
+- **`dev`** — Integration branch. All feature work merges here first. Pushes trigger prerelease builds.
+- **`feature/<name>`** or **`fix/<name>`** — Short-lived branches off `dev` for individual changes.
+
+### PR Rules
+
+| PR type | Base branch | Template | CI checks |
+|---------|------------|----------|-----------|
+| Feature / bugfix | `dev` | Default template | build-and-test |
+| Release | `main` | [release template](../.github/PULL_REQUEST_TEMPLATE/release.md) | build-and-test + pr-checks (version bump, changelog) |
+
+> **Important:** When creating a PR, GitHub defaults the base to `main`. **Change it to `dev`** for feature/fix PRs.
+
+### Release Process (dev → main)
+
+1. Ensure all work is merged to `dev` and CI is green
+2. Bump version in `CMakeLists.txt` (`GECKO_VERSION_PRERELEASE` or `VERSION`)
+3. Update `CHANGELOG.md` — move `[Unreleased]` entries to a new version section
+4. Commit & push to `dev`
+5. Create PR: **dev → main** using the [release template](https://github.com/briandl2000/Gecko/compare/main...dev?template=release.md)
+6. Wait for all CI checks to pass (build-and-test + pr-checks)
+7. Merge with **Create a merge commit** (preserves dev history)
+8. CI automatically tags the release and creates GitHub release with packages
+
 ## Version control habits
 
 - Prefer small, focused commits.
 - Commit messages should explain **why** (not just what).
 - Use short-lived feature branches when work spans multiple commits.
 
-Suggested branch style:
-- `main` (always builds)
-- `feature/<short-name>` (merge when stable)
-
 ## Change size rule
 
-If a change feels scary to review, it’s too big.
+If a change feels scary to review, it's too big.
 
 - Split by subsystem (`platform` vs `runtime`) or by capability ("window" vs "input").
 - Prefer adding a minimal API and one implementation path before generalizing.
 
-## PR / review checklist (even if you’re solo)
+## PR / review checklist (even if you're solo)
 
-- Builds Debug + Release
+- Builds Debug + Release on both Linux and Windows
 - Run at least one example affected by the change
 - New public APIs are documented (docs hub + any relevant guide)
 - No accidental module boundary leaks (Core should not depend on Platform)


### PR DESCRIPTION
- Default PR template warns to change base branch to dev
- Feature template reminds to target dev
- Release template adds merge instructions (use merge commit)
- Contributing docs now document full branching model and release steps