### PR TITLE
chore: bump version to alpha.3 and update CI release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,9 @@ jobs:
               --notes "" \
               release/*.zip
           else
-            # Main: auto-generated notes from commits since last release tag
+            # Main: extract changelog section for this version as the release description
+            VERSION_STR="${{ needs.resolve-version.outputs.version }}"
+            python3 -c "import re,sys;t=open('CHANGELOG.md').read();m=re.search(r'## \['+re.escape(sys.argv[1])+r'\](.*?)(?=\n## \[|\Z)',t,re.DOTALL);print(m.group(1).strip()if m else '')" "$VERSION_STR" > release_notes.md
             FLAGS=""
             if [ "${{ needs.resolve-version.outputs.prerelease }}" = "true" ]; then
               FLAGS="--prerelease"
@@ -391,6 +393,6 @@ jobs:
             gh release create "${{ needs.resolve-version.outputs.tag }}" \
               --title "Gecko ${{ needs.resolve-version.outputs.version }}" \
               ${FLAGS} \
-              --generate-notes \
+              --notes-file release_notes.md \
               release/*.zip
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0-alpha.3]
+
+### Changed
+- CI: main branch releases now use the CHANGELOG section for the release description instead of auto-generated commit notes
+- CI: dev build releases no longer include a description
+
 ## [0.0.0-alpha.2]
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Gecko VERSION 0.0.0 LANGUAGES C CXX)
 
 # Optional SemVer prerelease identifier (repo-controlled).
 # Examples: "alpha.1", "beta.2", "rc.1". Set to "" for a normal release.
-set(GECKO_VERSION_PRERELEASE "alpha.2")
+set(GECKO_VERSION_PRERELEASE "alpha.3")
 
 if(GECKO_VERSION_PRERELEASE STREQUAL "")
   set(GECKO_VERSION_FULL "${PROJECT_VERSION}")


### PR DESCRIPTION
<!-- ⚠️  Most PRs should target 'dev', NOT main.
     Change the base branch if needed. Only dev → main merges (releases) should target main.
     For release PRs, use: https://github.com/briandl2000/Gecko/compare/main...dev?template=release.md -->

## Description
Updating versioning for next release

### Pre-merge Checklist
- [x] **Base branch is `dev`** (not `main`)
- [x] CI passes (build + tests on both platforms)
- [x] Code follows [coding standards](docs/CODING_STANDARDS.md)
- [x] Added/updated tests (if applicable)
- [x] Change log updated
